### PR TITLE
Update helm ci to clone the AWX operator repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Output Python info
+        run: python --version && which python
+
+      - name: Clone ansible/awx-operator
+        run: python ./clone-awx-operator.py
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.10.0
+
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.10.0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.10.0
 
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.10.0
-
       - name: Build operator image and load into kind
         run: |
           IMG=awx-operator-ci make docker-build


### PR DESCRIPTION
This PR modifies the ci workflow to add steps that:

- Setup python with a version that matches CI in `ansible/awx-operator`: https://github.com/ansible/awx-operator/blob/8224b0b3543ba0e2d5e7f0dfd81ca5e2443725c7/.github/workflows/ci.yaml#L26
- Clone the relevant bits of the `ansible/awx-operator` repo.

This PR also removes a duplicate step to create a kind cluster.