### PR TITLE
Add overlay for deployment

### DIFF
--- a/.helm/starter/templates/operator-controller/_operator-controller.tpl
+++ b/.helm/starter/templates/operator-controller/_operator-controller.tpl
@@ -1,0 +1,5 @@
+{{/*
+This template gets filled with the operator SDK's controller definition
+during chart build
+*/}}
+{{- define "awx-operator.controller" -}}

--- a/.helm/starter/templates/operator-controller/controller-overlay.yaml
+++ b/.helm/starter/templates/operator-controller/controller-overlay.yaml
@@ -1,0 +1,4 @@
+{{- $operatorControllerTemplate := (include "awx-operator.controller" $) | fromYaml }}
+{{- $_ := mergeOverwrite $operatorControllerTemplate (index $.Values "operator-controller") }}
+
+{{ $operatorControllerTemplate | toYaml }}

--- a/.helm/starter/values.yaml
+++ b/.helm/starter/values.yaml
@@ -17,3 +17,5 @@ AWX:
     password: Unset
     sslmode: prefer
     type: unmanaged
+
+controller: {}

--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,7 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	for file in charts/$(CHART_NAME)/raw-files/*rolebinding*; do\
 		$(YQ) -i '.subjects[0].namespace = "{{ .Release.Namespace }}"' $${file};\
 	done
-	# Add .spec.replicas for the controller-manager deployment
-	for file in charts/$(CHART_NAME)/raw-files/deployment-*-controller-manager.yaml; do\
-		$(YQ) -i '.spec.replicas = "{{ (.Values.Operator).replicas | default 1 }}"' $${file};\
-	done
+
 	# Correct .metadata.name for cluster scoped resources
 	cluster_scoped_files="charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-metrics-reader.yaml charts/$(CHART_NAME)/raw-files/clusterrole-awx-operator-proxy-role.yaml";\
 	for file in $${cluster_scoped_files}; do\
@@ -162,10 +159,16 @@ helm-chart-generate: kustomize helm kubectl-slice yq charts
 	done
 	# Correct the reference for the clusterrolebinding
 	$(YQ) -i '.roleRef.name += "-{{ .Release.Name }}"' 'charts/$(CHART_NAME)/raw-files/clusterrolebinding-awx-operator-proxy-rolebinding.yaml'
-	# Correct .spec.replicas type for the controller-manager deployment
+
+	# Feed controller deployment file into template to allow for override from values
 	for file in charts/$(CHART_NAME)/raw-files/deployment-*-controller-manager.yaml; do\
-		$(SED_I) "s/'{{ (.Values.Operator).replicas | default 1 }}'/{{ (.Values.Operator).replicas | default 1 }}/g" $${file};\
+		cat $${file} >> charts/$(CHART_NAME)/templates/operator-controller/_operator-controller.tpl;\
+		echo "\n---" >> charts/$(CHART_NAME)/templates/operator-controller/_operator-controller.tpl;\
+		rm -f $${file} ;\
 	done
+	echo '{{- end -}}' >> charts/$(CHART_NAME)/templates/operator-controller/_operator-controller.tpl
+
+
 	# move all custom resource definitions to crds folder
 	mkdir charts/$(CHART_NAME)/crds
 	mv charts/$(CHART_NAME)/raw-files/customresourcedefinition*.yaml charts/$(CHART_NAME)/crds/.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use `--force-conflicts` flag to resolve the conflict.
 kubectl apply --server-side --force-conflicts -k github.com/ansible/awx-operator/config/crd?ref=<VERSION>
 ```
 
-## Configuration
+## Custom Resource Configuration
 
 The goal of adding helm configurations is to abstract out and simplify the creation of multi-resource configs. The `AWX.spec` field maps directly to the spec configs of the `AWX` resource that the operator provides, which are detailed in the [main README](https://github.com/ansible/awx-operator/blob/devel/README.md). Other sub-config can be added with the goal of simplifying more involved setups that require additional resources to be specified.
 
@@ -246,6 +246,28 @@ AWX:
 
 ## Values Summary
 
+### Controller
+The configuration of the `awx-operator-controller-manager` `Deployment` resource can be overridden by the
+`operator-controller` field. Any fields specified under this key will map directly onto the root hierarchy of the [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) configuration.
+
+For example, to override the replicas of the controller deployment, use:
+
+```yml
+# values
+operator-controller:
+  spec:
+    replicas: 4
+```
+
+Similarly, to add or override annotations:
+```yml
+#values
+operator-controller:
+  metadata:
+    annotations:
+      my-key: my-value
+```
+
 ### AWX
 
 | Value | Description | Default |
@@ -262,12 +284,6 @@ AWX:
 | Value | Description | Default |
 |---|---|---|
 | `extraDeploy` | array of additional resources to be deployed (supports YAML or literal "\|") | - |
-
-### Operator
-
-| Value | Description | Default |
-|---|---|---|
-| `Operator.replicas` | Number of controller-manager instance replicas | `1` |
 
 ### customSecrets
 
@@ -399,10 +415,6 @@ Where possible, defer to `AWX.spec` configs before applying the abstracted confi
 ### Building and Testing
 
 This chart is built using the Makefile in the [awx-operator repo](https://github.com/ansible/awx-operator). Clone the repo and run `make helm-chart`. This will create the awx-operator chart in the `charts/awx-operator` directory. In this process, the contents of the `.helm/starter` directory will be added to the chart.
-
-### Future Goals
-
-All values under the `AWX` header are focused on configurations that use the operator. Configurations that relate to the Operator itself could be placed under an `Operator` heading, but that may add a layer of complication over current development.
 
 ## Chart Publishing
 


### PR DESCRIPTION
Closes #14. Deployment resource is now fully templatable via .Values.controller.spec, .labels, and .annotations. 

Only regression I see is that the previously spliced-in template for .Values.Operator.replicas will not work, but I believe this setup is more scalable