### PR TITLE
Fixed AWX labels

### DIFF
--- a/.helm/starter/templates/awx-deploy.yaml
+++ b/.helm/starter/templates/awx-deploy.yaml
@@ -7,11 +7,11 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   {{- with .labels }}
   labels:
-    {{ . | toYaml }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   {{- with .annotations }}
-  labels:
-    {{ . | toYaml }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
 {{- /* Provide custom persistent volumes configs if enabled */}}


### PR DESCRIPTION
Fixes oversight in #21 - corrects annotation key and makes templates able to handle multi-value map. Tested with the following values:

```yml
AWX:
  enabled: true
  annotations:
    foo: bar
    second: line
  labels:
    foo: baz
    second: line
```

Output:

```yml
# Source: awx-operator/templates/awx-deploy.yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
  namespace: default
  labels:
    foo: baz
    second: line
  annotations:
    foo: bar
    second: line
spec:
  admin_user: admin
  security_context_settings:
    runAsGroup: 0
    runAsUser: 0
    fsGroup: 0
    fsGroupChangePolicy: OnRootMismatch

```