### PR TITLE
add chart release environment and deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,15 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    environment:
+      name: chart-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY }}
+          persist-credentials: true
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
This PR should fix the issue with branch protection rules breaking the release workflow. I've added an environment with a private key as well as a deploy key with the corresponding public part of the key. Also modified the branch ruleset for main to allow deploy keys to bypass branch protection.