### PR TITLE
Changing to manual chart generation validation

### DIFF
--- a/.github/workflows/committed-chart.yaml
+++ b/.github/workflows/committed-chart.yaml
@@ -1,0 +1,32 @@
+name: Check chart generation
+
+
+on:
+  pull_request:
+
+jobs:
+  check-chart-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate the helm chart
+        run: make helm-chart-generate
+
+      - name: Check for changes in the charts directory
+        id: check_chart_changes
+        run: >-
+          git status --porcelain charts/
+          | grep -q "." && echo "chart_changes=true" >> $GITHUB_OUTPUT
+          || echo "chart_changes=false" >> $GITHUB_OUTPUT
+
+      # split up to cut down on verbosity in git check command
+      - name: Ensure the helm chart is fully committed
+        if: ${{ steps.check_chart_changes.outputs.chart_changes == 'true' }}
+        run: |
+          git diff charts/
+          echo "::error title=Uncommitted-Chart::Chart is not up to date. Run 'make helm-chart-generate' locally and commit the changes."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'charts/**'
 
 jobs:
   release:
@@ -21,31 +23,8 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Generate Chart
-        run: make helm-chart-generate
-
-      - name: Check for changes to generated helm chart
-        id: check_chart_changes
-        run: >-
-          git status --porcelain charts/
-          | grep -q "." && echo "chart_changes=true" >> $GITHUB_OUTPUT
-          || echo "chart_changes=false" >> $GITHUB_OUTPUT
-
-      # If we generated a new helm chart, we need to commit it
-      # We need to do this step because our helm chart is not the source of truth, it's generated from starter
-      # Note that failing to do this doesn't break this release, but it can break future ones and make the release state confusing
-      - name: Commit generated chart
-        if: steps.check_chart_changes.outputs.chart_changes == 'true'
-        run: |
-          git pull --rebase origin main
-          git add charts/
-          git commit -m "Generated chart for release"
-          git push
-
       # Chart releaser will internally only run if there is a diff in charts,
-      # but we explicitly check to keep the chart releaser and our generates charts/ dir in sync
       - name: Run chart-releaser
-        if: steps.check_chart_changes.outputs.chart_changes == 'true'
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -87,17 +87,17 @@ Releases occur using the [chart-releaser](https://github.com/helm/chart-releaser
 Chart-releaser is designed to use the `charts` directory as the source of truth for the current state of the chart.
 If there are changes to that directory, the action generates a release.
 Unlike many other helm charts, this one is generated on the fly by pulling in the awx-operator source code.
-As a result, the release workflow also commits the state of the generated chart to the `charts` directory.
 
-> The `charts/` directory is a reflection of the release state, not a source of truth to edit for new features.
-> Any changes to helm chart functionality must be applied to the starter template.
+As a result, any PR that changes the chart generation must run `make helm-chart-generate` and commit the chart changes as well.
 
 ### Versioning
+The current CI setup does not run chart releases for PRs that do not change the generated chart.
 
-The current CI setup will skip releases for commits that don't make any changes to the generated chart.
-The use case for this is documentation or other file updates that don't impact the helm chart.
-However *any* release that affects helm chart generation *must* increment the `version` field in `.helm/starter/Chart.yaml`, which is our source of truth for versioning in this repo.
+*Any* release that affects helm chart generation *must* increment the `version` field in `.helm/starter/Chart.yaml`, which is our source of truth for versioning in this repo. Follow the [semantic versioning](https://helm.sh/docs/topics/charts/#charts-and-versioning) guidelines outlined by the helm documentation.
 
+The `appVersion` field in `.helm/starter/Chart.yaml` is the source of truth for the version of AWX Operator that is pulled into the chart templates.
+
+> Before version 3.0.0 of this Chart, the `version` field matched the AWX Operator version. The `version` and `appVersion` fields are independent and can be incremented separately to reflect changes to the chart or the underlying app it installs.
 
 ## Custom Resource Configuration
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Chart-releaser is designed to use the `charts` directory as the source of truth 
 If there are changes to that directory, the action generates a release.
 Unlike many other helm charts, this one is generated on the fly by pulling in the awx-operator source code.
 
-As a result, any PR that changes the chart generation must run `make helm-chart-generate` and commit the chart changes as well.
+As a result, submitting a pull request that modifies the helm chart generation requires you to run `make helm-chart-generate` and commit the chart changes.
 
 ### Versioning
 The current CI setup does not run chart releases for PRs that do not change the generated chart.

--- a/charts/awx-operator/.helmignore
+++ b/charts/awx-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/awx-operator/Chart.yaml
+++ b/charts/awx-operator/Chart.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v2
+description: The community-supported AWX Operator Helm Chart
+name: awx-operator
+type: application
+# the current version of this helm chart
+version: 3.0.0
+# The version of the awx-operator to install
+appVersion: 2.19.1

--- a/charts/awx-operator/crds/customresourcedefinition-awxbackups.awx.ansible.com.yaml
+++ b/charts/awx-operator/crds/customresourcedefinition-awxbackups.awx.ansible.com.yaml
@@ -1,0 +1,142 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awxbackups.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWXBackup
+    listKind: AWXBackupList
+    plural: awxbackups
+    singular: awxbackup
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Schema validation for the AWXBackup CRD
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                additional_labels:
+                  description: Additional labels defined on the resource, which should be propagated to child resources
+                  items:
+                    type: string
+                  type: array
+                backup_pvc:
+                  description: Name of the backup PVC
+                  type: string
+                backup_pvc_namespace:
+                  description: (Deprecated) Namespace the PVC is in
+                  type: string
+                backup_resource_requirements:
+                  description: Resource requirements for the management pod used to create a backup
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
+                backup_storage_class:
+                  description: Storage class to use when creating PVC for backup
+                  type: string
+                backup_storage_requirements:
+                  description: Storage requirements for backup PVC (may be similar to existing postgres PVC backing up from)
+                  type: string
+                clean_backup_on_delete:
+                  description: Flag to indicate if backup should be deleted on PVC if AWXBackup object is deleted
+                  type: boolean
+                db_management_pod_node_selector:
+                  description: nodeSelector for the Postgres pods to backup
+                  type: string
+                deployment_name:
+                  description: Name of the deployment to be backed up
+                  type: string
+                image_pull_policy:
+                  default: IfNotPresent
+                  description: The image pull policy
+                  enum:
+                    - Always
+                    - always
+                    - Never
+                    - never
+                    - IfNotPresent
+                    - ifnotpresent
+                  type: string
+                no_log:
+                  default: true
+                  description: Configure no_log for no_log tasks
+                  type: boolean
+                pg_dump_suffix:
+                  description: Additional parameters for the pg_dump command
+                  type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for backing up data
+                  type: string
+                precreate_partition_hours:
+                  description: Number of hours worth of events table partitions to precreate before backup to avoid pg_dump locks.
+                  format: int32
+                  type: integer
+                set_self_labels:
+                  default: true
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+              required:
+                - deployment_name
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              properties:
+                backupClaim:
+                  description: Backup persistent volume claim
+                  type: string
+                backupDirectory:
+                  description: Backup directory name on the specified pvc
+                  type: string
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/awx-operator/crds/customresourcedefinition-awxmeshingresses.awx.ansible.com.yaml
+++ b/charts/awx-operator/crds/customresourcedefinition-awxmeshingresses.awx.ansible.com.yaml
@@ -1,0 +1,456 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awxmeshingresses.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWXMeshIngress
+    listKind: AWXMeshIngressList
+    plural: awxmeshingresses
+    singular: awxmeshingress
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AWXMeshIngress is the Schema for the awxmeshingresses API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of AWXMeshIngress
+              properties:
+                affinity:
+                  description: Scheduling constraints to apply to the Pod definition
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                deployment_name:
+                  description: Name of the AWX deployment to create the Mesh Ingress for.
+                  type: string
+                external_hostname:
+                  description: External hostname to use for the Mesh Ingress.
+                  type: string
+                external_ipaddress:
+                  description: External IP address to use for the Mesh Ingress.
+                  type: string
+                image_pull_secrets:
+                  description: Image pull secrets for Mesh Ingress containers.
+                  items:
+                    type: string
+                  type: array
+                ingress_annotations:
+                  description: Annotations to add to the Ingress Controller
+                  type: string
+                ingress_api_version:
+                  description: The Ingress API version to use
+                  type: string
+                ingress_class_name:
+                  description: The name of ingress class to use instead of the cluster default.
+                  type: string
+                ingress_controller:
+                  description: Special configuration for specific Ingress Controllers
+                  type: string
+                ingress_type:
+                  description: The ingress type to use to reach the deployed instance
+                  enum:
+                    - none
+                    - Ingress
+                    - ingress
+                    - IngressRouteTCP
+                    - ingressroutetcp
+                    - Route
+                    - route
+                  type: string
+                node_selector:
+                  description: Assign the Mesh Ingress Pod to the specified node.
+                  type: string
+                tolerations:
+                  description: Scheduling tolerations for the Mesh Ingress instance.
+                  type: string
+                topology_spread_constraints:
+                  description: Topology spread constraints for the Mesh Ingress instance.
+                  type: string
+              required:
+                - deployment_name
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status defines the observed state of AWXMeshIngress
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/awx-operator/crds/customresourcedefinition-awxrestores.awx.ansible.com.yaml
+++ b/charts/awx-operator/crds/customresourcedefinition-awxrestores.awx.ansible.com.yaml
@@ -1,0 +1,146 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awxrestores.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWXRestore
+    listKind: AWXRestoreList
+    plural: awxrestores
+    singular: awxrestore
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Schema validation for the AWXRestore CRD
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                additional_labels:
+                  description: Additional labels defined on the resource, which should be propagated to child resources
+                  items:
+                    type: string
+                  type: array
+                backup_dir:
+                  description: Backup directory name, set as a status found on the awxbackup object (backupDirectory)
+                  type: string
+                backup_name:
+                  description: AWXBackup object name
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be restored from, set as a status found on the awxbackup object (backupClaim)
+                  type: string
+                backup_pvc_namespace:
+                  description: (Deprecated) Namespace the PVC is in
+                  type: string
+                backup_source:
+                  description: Backup source
+                  enum:
+                    - Backup CR
+                    - PVC
+                  type: string
+                cluster_name:
+                  description: Cluster name
+                  type: string
+                db_management_pod_node_selector:
+                  description: nodeSelector for the Postgres pods to backup
+                  type: string
+                deployment_name:
+                  description: Name of the restored deployment. This should be different from the original deployment name if the original deployment still exists.
+                  type: string
+                force_drop_db:
+                  default: false
+                  description: Force drop the database before restoring. USE WITH CAUTION!
+                  type: boolean
+                image_pull_policy:
+                  default: IfNotPresent
+                  description: The image pull policy
+                  enum:
+                    - Always
+                    - always
+                    - Never
+                    - never
+                    - IfNotPresent
+                    - ifnotpresent
+                  type: string
+                no_log:
+                  default: true
+                  description: Configure no_log for no_log tasks
+                  type: boolean
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for backing up data
+                  type: string
+                restore_resource_requirements:
+                  description: Resource requirements for the management pod that restores AWX from a backup
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
+                set_self_labels:
+                  default: true
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                spec_overrides:
+                  description: Overrides for the AWX spec
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - deployment_name
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                restoreComplete:
+                  description: Restore process complete
+                  type: boolean
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/awx-operator/crds/customresourcedefinition-awxs.awx.ansible.com.yaml
+++ b/charts/awx-operator/crds/customresourcedefinition-awxs.awx.ansible.com.yaml
@@ -1,0 +1,2049 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awxs.awx.ansible.com
+spec:
+  group: awx.ansible.com
+  names:
+    kind: AWX
+    listKind: AWXList
+    plural: awxs
+    singular: awx
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Schema validation for the AWX CRD
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                additional_labels:
+                  description: Additional labels defined on the resource, which should be propagated to child resources
+                  items:
+                    type: string
+                  type: array
+                admin_email:
+                  description: The admin user email
+                  type: string
+                admin_password_secret:
+                  description: Secret where the admin password can be found
+                  maxLength: 255
+                  pattern: ^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$
+                  type: string
+                admin_user:
+                  default: admin
+                  description: Username to use for the admin account
+                  type: string
+                affinity:
+                  description: If specified, the pod's scheduling constraints
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  description: Common annotations for both Web and Task deployments.
+                  type: string
+                api_urlpattern_prefix:
+                  description: An optional configuration to add a prefix in the API URL path
+                  type: string
+                api_version:
+                  description: apiVersion of the deployment type
+                  type: string
+                auto_upgrade:
+                  default: true
+                  description: Should AWX instances be automatically upgraded when operator gets upgraded
+                  type: boolean
+                broadcast_websocket_secret:
+                  description: Secret where the broadcast websocket secret can be found
+                  maxLength: 255
+                  pattern: ^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$
+                  type: string
+                bundle_cacert_secret:
+                  description: Secret where can be found the trusted Certificate Authority Bundle
+                  type: string
+                ca_trust_bundle:
+                  description: Path where the trusted CA bundle is available
+                  type: string
+                control_plane_ee_image:
+                  description: Registry path to the Execution Environment container image to use on control plane pods
+                  type: string
+                control_plane_priority_class:
+                  description: Assign a preexisting priority class to the control plane pods
+                  type: string
+                create_preload_data:
+                  default: true
+                  description: Whether or not to preload data upon instance creation
+                  type: boolean
+                csrf_cookie_secure:
+                  description: Set csrf cookie secure mode for web
+                  type: string
+                deployment_type:
+                  description: Name of the deployment type
+                  type: string
+                development_mode:
+                  description: If the deployment should be done in development mode
+                  type: boolean
+                ee_extra_env:
+                  type: string
+                ee_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Execution container
+                  type: string
+                ee_images:
+                  description: Registry path to the Execution Environment container to use
+                  items:
+                    properties:
+                      image:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  type: array
+                ee_pull_credentials_secret:
+                  description: Secret where pull credentials for registered ees can be found
+                  type: string
+                ee_resource_requirements:
+                  description: Resource requirements for the ee container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                extra_settings:
+                  description: Extra settings to specify for AWX
+                  items:
+                    properties:
+                      setting:
+                        type: string
+                      value:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  type: array
+                extra_settings_files:
+                  description: Extra ConfigMaps or Secrets of settings files to specify for AWX
+                  properties:
+                    configmaps:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    secrets:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                extra_volumes:
+                  description: Specify extra volumes to add to the application pod
+                  type: string
+                garbage_collect_secrets:
+                  default: false
+                  description: Whether or not to remove secrets upon instance removal
+                  type: boolean
+                host_aliases:
+                  description: HostAliases for app containers
+                  items:
+                    properties:
+                      hostnames:
+                        items:
+                          type: string
+                        type: array
+                      ip:
+                        type: string
+                    type: object
+                  type: array
+                hostname:
+                  description: (Deprecated) The hostname of the instance
+                  type: string
+                image:
+                  description: Registry path to the application container to use
+                  type: string
+                image_pull_policy:
+                  default: IfNotPresent
+                  description: The image pull policy
+                  enum:
+                    - Always
+                    - always
+                    - Never
+                    - never
+                    - IfNotPresent
+                    - ifnotpresent
+                  type: string
+                image_pull_secret:
+                  description: (Deprecated) Image pull secret for app and database containers
+                  type: string
+                image_pull_secrets:
+                  description: Image pull secrets for app and database containers
+                  items:
+                    type: string
+                  type: array
+                image_version:
+                  description: Application container image version to use
+                  type: string
+                ingress_annotations:
+                  description: Annotations to add to the Ingress Controller
+                  type: string
+                ingress_api_version:
+                  description: The Ingress API version to use
+                  type: string
+                ingress_class_name:
+                  description: The name of ingress class to use instead of the cluster default.
+                  type: string
+                ingress_controller:
+                  description: Special configuration for specific Ingress Controllers
+                  type: string
+                ingress_hosts:
+                  description: Ingress hostnames of the instance
+                  items:
+                    properties:
+                      hostname:
+                        description: Hostname of the instance
+                        type: string
+                      tls_secret:
+                        description: Secret where the Ingress TLS secret can be found
+                        type: string
+                    type: object
+                  type: array
+                ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
+                ingress_path_type:
+                  description: The ingress path type for the deployed service
+                  type: string
+                ingress_tls_secret:
+                  description: (Deprecated) Secret where the Ingress TLS secret can be found
+                  type: string
+                ingress_type:
+                  description: The ingress type to use to reach the deployed instance
+                  enum:
+                    - none
+                    - Ingress
+                    - ingress
+                    - Route
+                    - route
+                  type: string
+                init_container_extra_commands:
+                  description: Extra commands for the init container
+                  type: string
+                init_container_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the init container
+                  type: string
+                init_container_image:
+                  description: Registry path to the init container to use
+                  type: string
+                init_container_image_version:
+                  description: Init container image version to use
+                  type: string
+                init_container_resource_requirements:
+                  description: Resource requirements for the init container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                init_projects_container_image:
+                  description: Registry path to the init projects container to use
+                  type: string
+                ipv6_disabled:
+                  default: false
+                  description: Disable web container's nginx ipv6 listener
+                  type: boolean
+                kind:
+                  description: Kind of the deployment type
+                  type: string
+                ldap_cacert_secret:
+                  description: Secret where can be found the LDAP trusted Certificate Authority Bundle
+                  type: string
+                ldap_password_secret:
+                  description: Secret where can be found the LDAP bind password
+                  type: string
+                loadbalancer_class:
+                  default: ""
+                  description: Class of LoadBalancer to use
+                  type: string
+                loadbalancer_ip:
+                  default: ""
+                  description: Assign LoadBalancer IP address
+                  type: string
+                loadbalancer_port:
+                  default: 80
+                  description: Port to use for the loadbalancer
+                  type: integer
+                loadbalancer_protocol:
+                  default: http
+                  description: Protocol to use for the loadbalancer
+                  enum:
+                    - http
+                    - https
+                  type: string
+                metrics_utility_configmap:
+                  description: Metrics-Utility ConfigMap
+                  type: string
+                metrics_utility_console_enabled:
+                  default: false
+                  description: Enable metrics utility shipping to Red Hat Hybrid Cloud Console
+                  type: boolean
+                metrics_utility_cronjob_gather_schedule:
+                  default: '@hourly'
+                  description: Metrics-Utility Gather Data CronJob Schedule
+                  type: string
+                metrics_utility_cronjob_report_schedule:
+                  default: '@monthly'
+                  description: Metrics-Utility Report CronJob Schedule
+                  type: string
+                metrics_utility_enabled:
+                  default: false
+                  description: Enable metrics utility
+                  type: boolean
+                metrics_utility_image:
+                  description: Metrics-Utility Image
+                  type: string
+                metrics_utility_image_pull_policy:
+                  description: Metrics-Utility Image PullPolicy
+                  type: string
+                metrics_utility_image_version:
+                  description: Metrics-Utility Image Version
+                  type: string
+                metrics_utility_pvc_claim:
+                  description: Metrics-Utility PVC Claim
+                  type: string
+                metrics_utility_pvc_claim_size:
+                  default: 5Gi
+                  description: Metrics-Utility PVC Claim Size
+                  type: string
+                metrics_utility_pvc_claim_storage_class:
+                  description: Metrics-Utility PVC Claim Storage Class
+                  type: string
+                metrics_utility_secret:
+                  description: Metrics-Utility Secret
+                  type: string
+                metrics_utility_ship_target:
+                  description: Metrics-Utility Ship Target
+                  type: string
+                nginx_listen_queue_size:
+                  description: Set the socket listen queue size for nginx (defaults to same as uwsgi)
+                  type: integer
+                nginx_worker_connections:
+                  description: Set the number of connections per worker for nginx
+                  type: integer
+                nginx_worker_cpu_affinity:
+                  description: Set the CPU affinity for nginx workers
+                  type: string
+                nginx_worker_processes:
+                  description: Set the number of workers for nginx
+                  type: integer
+                no_log:
+                  default: true
+                  description: Configure no_log for no_log tasks
+                  type: boolean
+                node_selector:
+                  description: nodeSelector for the pods
+                  type: string
+                nodeport_port:
+                  description: Port to use for the nodeport
+                  type: integer
+                old_postgres_configuration_secret:
+                  description: Secret where the old database configuration can be found for data migration
+                  maxLength: 255
+                  pattern: ^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$
+                  type: string
+                postgres_configuration_secret:
+                  description: Secret where the database configuration can be found
+                  type: string
+                postgres_data_volume_init:
+                  description: Sets permissions on the /var/lib/pgdata/data for postgres container using an init container (not Openshift)
+                  type: boolean
+                postgres_extra_args:
+                  items:
+                    type: string
+                  type: array
+                postgres_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Postgres container
+                  type: string
+                postgres_extra_volumes:
+                  description: Specify extra volumes to add to the application pod
+                  type: string
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                postgres_init_container_commands:
+                  description: Customize the postgres init container commands (Non Openshift)
+                  type: string
+                postgres_init_container_resource_requirements:
+                  description: (Deprecated, use postgres_resource_requirements parameter) Resource requirements for the postgres init container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                postgres_keep_pvc_after_upgrade:
+                  description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                  type: boolean
+                postgres_keepalives:
+                  default: true
+                  description: Controls whether client-side TCP keepalives are used for Postgres connections.
+                  type: boolean
+                postgres_keepalives_count:
+                  default: 5
+                  description: Controls the number of TCP keepalives that can be lost before the client's connection to the server is considered dead.
+                  format: int32
+                  type: integer
+                postgres_keepalives_idle:
+                  default: 5
+                  description: Controls the number of seconds of inactivity after which TCP should send a keepalive message to the server.
+                  format: int32
+                  type: integer
+                postgres_keepalives_interval:
+                  default: 5
+                  description: Controls the number of seconds after which a TCP keepalive message that is not acknowledged by the server should be retransmitted.
+                  format: int32
+                  type: integer
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for data migration
+                  type: string
+                postgres_priority_class:
+                  description: Assign a preexisting priority class to the postgres pod
+                  type: string
+                postgres_resource_requirements:
+                  description: Resource requirements for the PostgreSQL container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      type: object
+                  type: object
+                postgres_security_context_settings:
+                  description: Key/values that will be set under the pod-level securityContext field
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                postgres_selector:
+                  description: nodeSelector for the Postgres pods
+                  type: string
+                postgres_storage_class:
+                  description: Storage class to use for the PostgreSQL PVC
+                  type: string
+                postgres_storage_requirements:
+                  description: Storage requirements for the PostgreSQL container
+                  properties:
+                    limits:
+                      properties:
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                postgres_tolerations:
+                  description: node tolerations for the Postgres pods
+                  type: string
+                projects_existing_claim:
+                  description: PersistentVolumeClaim to mount /var/lib/projects directory
+                  type: string
+                projects_persistence:
+                  default: false
+                  description: Whether or not the /var/lib/projects directory will be persistent
+                  type: boolean
+                projects_storage_access_mode:
+                  default: ReadWriteMany
+                  description: AccessMode for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                projects_storage_class:
+                  description: Storage class for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                projects_storage_size:
+                  default: 8Gi
+                  description: Size for the /var/lib/projects PersistentVolumeClaim
+                  type: string
+                projects_use_existing_claim:
+                  description: Using existing PersistentVolumeClaim
+                  enum:
+                    - _Yes_
+                    - _No_
+                  type: string
+                receptor_log_level:
+                  description: Set log level of receptor service
+                  type: string
+                redis_capabilities:
+                  description: Redis container capabilities
+                  items:
+                    type: string
+                  type: array
+                redis_image:
+                  description: Registry path to the redis container to use
+                  type: string
+                redis_image_version:
+                  description: Redis container image version to use
+                  type: string
+                redis_resource_requirements:
+                  description: Resource requirements for the redis container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                replicas:
+                  default: 1
+                  description: Number of instance replicas
+                  format: int32
+                  type: integer
+                route_api_version:
+                  description: The route API version to use
+                  type: string
+                route_host:
+                  description: The DNS to use to points to the instance
+                  type: string
+                route_tls_secret:
+                  description: Secret where the TLS related credentials are stored
+                  type: string
+                route_tls_termination_mechanism:
+                  default: Edge
+                  description: The secure TLS termination mechanism to use
+                  enum:
+                    - Edge
+                    - edge
+                    - Passthrough
+                    - passthrough
+                  type: string
+                rsyslog_args:
+                  items:
+                    type: string
+                  type: array
+                rsyslog_command:
+                  items:
+                    type: string
+                  type: array
+                rsyslog_extra_env:
+                  type: string
+                rsyslog_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the Rsyslog container
+                  type: string
+                rsyslog_resource_requirements:
+                  description: Resource requirements for the rsyslog container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                secret_key_secret:
+                  description: Secret where the secret key can be found
+                  maxLength: 255
+                  pattern: ^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$
+                  type: string
+                security_context_settings:
+                  description: Key/values that will be set under the pod-level securityContext field
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                service_account_annotations:
+                  description: ServiceAccount annotations
+                  type: string
+                service_annotations:
+                  description: Annotations to add to the service
+                  type: string
+                service_labels:
+                  description: Additional labels to apply to the service
+                  type: string
+                service_type:
+                  description: The service type to be used on the deployed instance
+                  enum:
+                    - LoadBalancer
+                    - loadbalancer
+                    - ClusterIP
+                    - clusterip
+                    - NodePort
+                    - nodeport
+                  type: string
+                session_cookie_secure:
+                  description: Set session cookie secure mode for web
+                  type: string
+                set_self_labels:
+                  default: true
+                  description: Maintain some of the recommended `app.kubernetes.io/*` labels on the resource (self)
+                  type: boolean
+                task_affinity:
+                  description: If specified, the pod's scheduling constraints
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                task_annotations:
+                  description: Task deployment annotations. This will override the general annotations parameter for the Task deployment.
+                  type: string
+                task_args:
+                  items:
+                    type: string
+                  type: array
+                task_command:
+                  items:
+                    type: string
+                  type: array
+                task_extra_env:
+                  type: string
+                task_extra_volume_mounts:
+                  description: Specify volume mounts to be added to Task container
+                  type: string
+                task_liveness_failure_threshold:
+                  default: 3
+                  description: Number of consecutive failure events to identify failure of task pod
+                  format: int32
+                  type: integer
+                task_liveness_initial_delay:
+                  default: 5
+                  description: Initial delay before starting liveness checks on task pod
+                  format: int32
+                  type: integer
+                task_liveness_period:
+                  default: 0
+                  description: Time period in seconds between each liveness check for the task pod
+                  format: int32
+                  type: integer
+                task_liveness_timeout:
+                  default: 1
+                  description: Number of seconds to wait for a probe response from task pod
+                  format: int32
+                  type: integer
+                task_manage_replicas:
+                  default: true
+                  description: Enables operator control of replicas count for the task deployment when set to 'true'
+                  type: boolean
+                task_node_selector:
+                  description: nodeSelector for the task pods
+                  type: string
+                task_privileged:
+                  default: false
+                  description: If a privileged security context should be enabled
+                  type: boolean
+                task_readiness_failure_threshold:
+                  default: 3
+                  description: Number of consecutive failure events to identify failure of task pod
+                  format: int32
+                  type: integer
+                task_readiness_initial_delay:
+                  default: 20
+                  description: Initial delay before starting readiness checks on task pod
+                  format: int32
+                  type: integer
+                task_readiness_period:
+                  default: 0
+                  description: Time period in seconds between each readiness check for the task pod
+                  format: int32
+                  type: integer
+                task_readiness_timeout:
+                  default: 1
+                  description: Number of seconds to wait for a probe response from task pod
+                  format: int32
+                  type: integer
+                task_replicas:
+                  description: Number of task instance replicas
+                  format: int32
+                  type: integer
+                task_resource_requirements:
+                  description: Resource requirements for the task container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                task_tolerations:
+                  description: node tolerations for the task pods
+                  type: string
+                task_topology_spread_constraints:
+                  description: topology rule(s) for the task pods
+                  type: string
+                termination_grace_period_seconds:
+                  description: Optional duration in seconds pods needs to terminate gracefully
+                  format: int32
+                  type: integer
+                tolerations:
+                  description: node tolerations for the pods
+                  type: string
+                topology_spread_constraints:
+                  description: topology rule(s) for the pods
+                  type: string
+                uwsgi_listen_queue_size:
+                  description: Set the socket listen queue size for uwsgi
+                  type: integer
+                uwsgi_processes:
+                  description: Set the number of uwsgi processes to run in a web container
+                  type: integer
+                web_affinity:
+                  description: If specified, the pod's scheduling constraints
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                web_annotations:
+                  description: Web deployment annotations. This will override the general annotations parameter for the Web deployment.
+                  type: string
+                web_args:
+                  items:
+                    type: string
+                  type: array
+                web_command:
+                  items:
+                    type: string
+                  type: array
+                web_extra_env:
+                  type: string
+                web_extra_volume_mounts:
+                  description: Specify volume mounts to be added to the Web container
+                  type: string
+                web_liveness_failure_threshold:
+                  default: 3
+                  description: Number of consecutive failure events to identify failure of web pod
+                  format: int32
+                  type: integer
+                web_liveness_initial_delay:
+                  default: 5
+                  description: Initial delay before starting liveness checks on web pod
+                  format: int32
+                  type: integer
+                web_liveness_period:
+                  default: 0
+                  description: Time period in seconds between each liveness check for the web pod
+                  format: int32
+                  type: integer
+                web_liveness_timeout:
+                  default: 1
+                  description: Number of seconds to wait for a probe response from web pod
+                  format: int32
+                  type: integer
+                web_manage_replicas:
+                  default: true
+                  description: Enables operator control of replicas count for the web deployment when set to 'true'
+                  type: boolean
+                web_node_selector:
+                  description: nodeSelector for the web pods
+                  type: string
+                web_readiness_failure_threshold:
+                  default: 3
+                  description: Number of consecutive failure events to identify failure of web pod
+                  format: int32
+                  type: integer
+                web_readiness_initial_delay:
+                  default: 20
+                  description: Initial delay before starting readiness checks on web pod
+                  format: int32
+                  type: integer
+                web_readiness_period:
+                  default: 0
+                  description: Time period in seconds between each readiness check for the web pod
+                  format: int32
+                  type: integer
+                web_readiness_timeout:
+                  default: 1
+                  description: Number of seconds to wait for a probe response from web pod
+                  format: int32
+                  type: integer
+                web_replicas:
+                  description: Number of web instance replicas
+                  format: int32
+                  type: integer
+                web_resource_requirements:
+                  description: Resource requirements for the web container
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          type: string
+                        ephemeral-storage:
+                          type: string
+                        memory:
+                          type: string
+                        storage:
+                          type: string
+                      type: object
+                  type: object
+                web_tolerations:
+                  description: node tolerations for the web pods
+                  type: string
+                web_topology_spread_constraints:
+                  description: topology rule(s) for the web pods
+                  type: string
+              type: object
+            status:
+              properties:
+                URL:
+                  description: URL to access the deployed instance
+                  type: string
+                adminPasswordSecret:
+                  description: Admin password secret name of the deployed instance
+                  type: string
+                adminUser:
+                  description: Admin user of the deployed instance
+                  type: string
+                broadcastWebsocketSecret:
+                  description: Broadcast websocket secret name of the deployed instance
+                  type: string
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                image:
+                  description: URL of the image used for the deployed instance
+                  type: string
+                migratedFromSecret:
+                  description: The secret used for migrating an old instance
+                  type: string
+                postgresConfigurationSecret:
+                  description: Postgres Configuration secret name of the deployed instance
+                  type: string
+                secretKeySecret:
+                  description: Secret key secret name of the deployed instance
+                  type: string
+                upgradedPostgresVersion:
+                  description: Status to indicate that the database has been upgraded to the version in the status
+                  type: string
+                version:
+                  description: Version of the deployed instance
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/awx-operator/templates/NOTES.txt
+++ b/charts/awx-operator/templates/NOTES.txt
@@ -1,0 +1,1 @@
+AWX Operator installed with Helm Chart version {{ .Chart.Version }}

--- a/charts/awx-operator/templates/_helpers.tpl
+++ b/charts/awx-operator/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Generate the name of the postgres secret, expects AWX context passed in
+*/}}
+{{- define "postgres.secretName" -}}
+{{ default (printf "%s-postgres-configuration" .Values.AWX.name) .Values.AWX.postgres.secretName }}
+{{- end }}

--- a/charts/awx-operator/templates/awx-deploy.yaml
+++ b/charts/awx-operator/templates/awx-deploy.yaml
@@ -1,0 +1,36 @@
+{{- if $.Values.AWX.enabled }}
+{{- with .Values.AWX }}
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  {{- with .labels }}
+  labels:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+{{- /* Provide custom persistent volumes configs if enabled */}}
+{{- include "spec.storageClassNames" $ }}
+{{- /* Provide custom secrets configs if enabled */}}
+{{- include "spec.secrets" $ }}
+{{- /* Include raw map from the values file spec */}}
+{{ .spec | toYaml | indent 2 }}
+{{- /* Provide security context defaults */}}
+  {{- if not (hasKey .spec "security_context_settings") }}
+  security_context_settings:
+    runAsGroup: 0
+    runAsUser: 0
+    fsGroup: 0
+    fsGroupChangePolicy: OnRootMismatch
+  {{- end }}
+{{- /* Postgres configs if enabled and not already present */}}
+  {{- if and .postgres.enabled (not (hasKey .spec "postgres_configuration_secret")) }}
+  postgres_configuration_secret: {{ include "postgres.secretName" $ }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/clusterrole-awx-operator-metrics-reader.yaml
+++ b/charts/awx-operator/templates/clusterrole-awx-operator-metrics-reader.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-metrics-reader-{{ .Release.Name }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/charts/awx-operator/templates/clusterrole-awx-operator-proxy-role.yaml
+++ b/charts/awx-operator/templates/clusterrole-awx-operator-proxy-role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-proxy-role-{{ .Release.Name }}
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/charts/awx-operator/templates/clusterrolebinding-awx-operator-proxy-rolebinding.yaml
+++ b/charts/awx-operator/templates/clusterrolebinding-awx-operator-proxy-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-proxy-rolebinding-{{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: awx-operator-proxy-role-{{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: awx-operator-controller-manager
+    namespace: '{{ .Release.Namespace }}'

--- a/charts/awx-operator/templates/configmap-awx-operator-awx-manager-config.yaml
+++ b/charts/awx-operator/templates/configmap-awx-operator-awx-manager-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :6789
+    metrics:
+      bindAddress: 127.0.0.1:8080
+
+    leaderElection:
+      leaderElect: true
+      resourceName: 811c9dc5.ansible.com
+    # leaderElectionReleaseOnCancel defines if the leader should step down volume
+    # when the Manager ends. This requires the binary to immediately end when the
+    # Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+    # speeds up voluntary leader transitions as the new leader don't have to wait
+    # LeaseDuration time first.
+    # In the default scaffold provided, the program ends immediately after
+    # the manager stops, so would be fine to enable this option. However,
+    # if you are doing or is intended to do any operation such as perform cleanups
+    # after the manager stops then its usage might be unsafe.
+    # leaderElectionReleaseOnCancel: true
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-awx-manager-config

--- a/charts/awx-operator/templates/extra-list.yaml
+++ b/charts/awx-operator/templates/extra-list.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraDeploy }}
+---
+  {{- if typeIs "string" . }}
+    {{- tpl . $ }}
+  {{- else }}
+    {{- tpl (. | toYaml | nindent 0) $ }}
+  {{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/operator-controller/_operator-controller.tpl
+++ b/charts/awx-operator/templates/operator-controller/_operator-controller.tpl
@@ -1,0 +1,100 @@
+{{/*
+This template gets filled with the operator SDK's controller definition
+during chart build
+*/}}
+{{- define "awx-operator.controller" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    helm.sh/chart: awx-operator
+  name: awx-operator-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      helm.sh/chart: awx-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: awx-manager
+      labels:
+        control-plane: controller-manager
+        helm.sh/chart: awx-operator
+    spec:
+      containers:
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - args:
+            - --health-probe-bind-address=:6789
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+            - --leader-election-id=awx-operator
+          env:
+            - name: ANSIBLE_GATHERING
+              value: explicit
+            - name: ANSIBLE_DEBUG_LOGS
+              value: "false"
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: quay.io/ansible/awx-operator:2.19.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6789
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: awx-manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6789
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 960Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      imagePullSecrets:
+        - name: redhat-operators-pull-secret
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: awx-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+
+---
+{{- end -}}

--- a/charts/awx-operator/templates/operator-controller/controller-overlay.yaml
+++ b/charts/awx-operator/templates/operator-controller/controller-overlay.yaml
@@ -1,0 +1,4 @@
+{{- $operatorControllerTemplate := (include "awx-operator.controller" $) | fromYaml }}
+{{- $_ := mergeOverwrite $operatorControllerTemplate (index $.Values "operator-controller") }}
+
+{{ $operatorControllerTemplate | toYaml }}

--- a/charts/awx-operator/templates/postgres-config.yaml
+++ b/charts/awx-operator/templates/postgres-config.yaml
@@ -1,0 +1,19 @@
+{{- if and $.Values.AWX.enabled $.Values.AWX.postgres.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgres.secretName" . }}
+  namespace: {{ $.Release.Namespace }}
+{{- with $.Values.AWX.postgres }}
+stringData:
+  host: {{ .host }}
+  port: {{ .port | quote }}
+  database: {{ .dbName }}
+  username: {{ .username }}
+  password: {{ .password }}
+  sslmode: {{ .sslmode }}
+  target_session_attrs: {{ .target_session_attrs | default "any" }}
+  type: {{ .type }}
+type: Opaque
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/role-awx-operator-awx-manager-role.yaml
+++ b/charts/awx-operator/templates/role-awx-operator-awx-manager-role.yaml
@@ -1,0 +1,152 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-awx-manager-role
+rules:
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - serviceaccounts
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - awx-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/scale
+      - statefulsets/scale
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+      - pods/attach
+      - pods/log
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - awx.ansible.com
+    resources:
+      - '*'
+      - awxbackups
+      - awxrestores
+    verbs:
+      - '*'
+  - apiGroups:
+      - traefik.containo.us
+      - traefik.io
+    resources:
+      - ingressroutetcps
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+      - watch

--- a/charts/awx-operator/templates/role-awx-operator-leader-election-role.yaml
+++ b/charts/awx-operator/templates/role-awx-operator-leader-election-role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-leader-election-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/charts/awx-operator/templates/rolebinding-awx-operator-awx-manager-rolebinding.yaml
+++ b/charts/awx-operator/templates/rolebinding-awx-operator-awx-manager-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-awx-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: awx-operator-awx-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: awx-operator-controller-manager
+    namespace: '{{ .Release.Namespace }}'

--- a/charts/awx-operator/templates/rolebinding-awx-operator-leader-election-rolebinding.yaml
+++ b/charts/awx-operator/templates/rolebinding-awx-operator-leader-election-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: awx-operator-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: awx-operator-controller-manager
+    namespace: '{{ .Release.Namespace }}'

--- a/charts/awx-operator/templates/secrets/_helpers.tpl
+++ b/charts/awx-operator/templates/secrets/_helpers.tpl
@@ -1,0 +1,170 @@
+{{/*
+Generate certificates for ingress
+*/}}
+{{- define "ingress.gen-certs" -}}
+{{- $ca := genCA "ingress-ca" 365 -}}
+{{- $cert := genSignedCert ( $.Values.AWX.spec.hostname | required "AWX.spec.hostname is required!" ) nil nil 365 $ca -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}
+
+{{/*
+Generate the name of the secret that contains the admin user password
+*/}}
+{{- define "admin.secretName" -}}
+{{ default (printf "%s-admin-password" $.Values.AWX.name) (default $.Values.customSecrets.admin.secretName $.Values.AWX.spec.admin_password_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the TLS information when ingress_type=route
+*/}}
+{{- define "routeTls.secretName" -}}
+{{ default (printf "%s-route-tls" $.Values.AWX.name) (default $.Values.customSecrets.routeTls.secretName $.Values.AWX.spec.route_tls_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the TLS information when ingress_type=ingress
+*/}}
+{{- define "ingressTls.secretName" -}}
+{{ default (printf "%s-ingress-tls" $.Values.AWX.name) (default $.Values.customSecrets.ingressTls.secretName $.Values.AWX.spec.ingress_tls_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the LDAP Certificate Authority
+*/}}
+{{- define "ldapCacert.secretName" -}}
+{{ default (printf "%s-custom-certs" $.Values.AWX.name) (default ($.Values.customSecrets.ldapCacert).secretName $.Values.AWX.spec.ldap_cacert_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the custom Certificate Authority
+*/}}
+{{- define "bundleCacert.secretName" -}}
+{{ default (printf "%s-custom-certs" $.Values.AWX.name) (default ($.Values.customSecrets.bundleCacert).secretName $.Values.AWX.spec.bundle_cacert_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the LDAP BIND DN password
+*/}}
+{{- define "ldap.secretName" -}}
+{{ default (printf "%s-ldap-password" $.Values.AWX.name) (default $.Values.customSecrets.ldap.secretName $.Values.AWX.spec.ldap_password_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the symmetric key for encryption
+*/}}
+{{- define "secretKey.secretName" -}}
+{{ default (printf "%s-secret-key" $.Values.AWX.name) (default $.Values.customSecrets.secretKey.secretName $.Values.AWX.spec.secret_key_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the default execution environment pull credentials
+*/}}
+{{- define "eePullCredentials.secretName" -}}
+{{ default (printf "%s-ee-pull-credentials" $.Values.AWX.name) (default $.Values.customSecrets.eePullCredentials.secretName $.Values.AWX.spec.ee_pull_credentials_secret) }}
+{{- end }}
+
+{{/*
+Generate the name of the secret that contains the default control plane pull credentials
+*/}}
+{{- define "cpPullCredentials.secretName" -}}
+{{ default (printf "%s-cp-pull-credentials" $.Values.AWX.name) (default $.Values.customSecrets.cpPullCredentials.secretName $.Values.AWX.spec.image_pull_secrets) }}
+{{- end }}
+
+{{/*
+Generate the .dockerconfigjson file unencoded.
+*/}}
+{{- define "dockerconfigjson.b64dec" }}
+  {{- print "{\"auths\":{" }}
+  {{- range $index, $item := . }}
+    {{- if $index }}
+      {{- print "," }}
+    {{- end }}
+    {{- printf "\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}" (default "https://index.docker.io/v1/" $item.registry) $item.username $item.password (default "" $item.email) (printf "%s:%s" $item.username $item.password | b64enc) }}
+  {{- end }}
+  {{- print "}}" }}
+{{- end }}
+
+{{/*
+Generate the base64-encoded .dockerconfigjson.
+*/}}
+{{- define "dockerconfigjson.b64enc" }}
+  {{- $list := ternary (list .) . (kindIs "map" .) }}
+  {{- include "dockerconfigjson.required" $list }}
+  {{- include "dockerconfigjson.b64dec" $list | b64enc }}
+{{- end }}
+
+{{/*
+Required values for .dockerconfigjson
+*/}}
+{{- define "dockerconfigjson.required" -}}
+  {{- range . -}}
+    {{- $_ := required "cpPullCredentials.dockerconfigjson[].username is required!" .username -}}
+    {{- $_ := required "cpPullCredentials.dockerconfigjson[].password is required!" .password -}}
+  {{- end -}}
+  {{/* Check for registry uniqueness */}}
+  {{- $registries := list -}}
+  {{- range . -}}
+    {{- $registries = append $registries (default "https://index.docker.io/v1/" .registry) -}}
+  {{- end -}}
+  {{- $_ := required "All cpPullCredentials.dockerconfigjson[].registry's must be unique!" (or (eq (len $registries) (len ($registries | uniq))) nil) -}}
+{{- end -}}
+
+{{/*
+Generate the name of the secrets
+*/}}
+{{- define "spec.secrets" -}}
+{{- /* secret configs if enabled */}}
+{{- if hasKey $.Values "customSecrets" }}
+{{- with $.Values.customSecrets }}
+{{- if .enabled }}
+  {{- if hasKey . "admin" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "admin_password_secret")) .admin.enabled }}
+  admin_password_secret: {{ include "admin.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "secretKey" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "secret_key_secret")) .secretKey.enabled }}
+  secret_key_secret: {{ include "secretKey.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "routeTls" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "route_tls_secret")) .routeTls.enabled }}
+  route_tls_secret: {{ include "routeTls.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ingressTls" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ingress_tls_secret")) .ingressTls.enabled }}
+  ingress_tls_secret: {{ include "ingressTls.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ldapCacert" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ldap_cacert_secret")) .ldapCacert.enabled }}
+  ldap_cacert_secret: {{ include "ldapCacert.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "bundleCacert" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "bundle_cacert_secret")) .bundleCacert.enabled }}
+  bundle_cacert_secret: {{ include "bundleCacert.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "ldap" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ldap_password_secret")) .ldap.enabled }}
+  ldap_password_secret: {{ include "ldap.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "eePullCredentials" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "ee_pull_credentials_secret")) .eePullCredentials.enabled }}
+  ee_pull_credentials_secret: {{ include "eePullCredentials.secretName" $ }}
+  {{- end }}
+  {{- end }}
+  {{- if hasKey . "cpPullCredentials" }}
+  {{- if and (not (hasKey $.Values.AWX.spec "image_pull_secrets")) .cpPullCredentials.enabled }}
+  image_pull_secrets:
+    - {{ include "cpPullCredentials.secretName" $ }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/admin-password-secret.yaml
+++ b/charts/awx-operator/templates/secrets/admin-password-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "admin" }}
+{{- with $.Values.customSecrets.admin }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "admin.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  password: {{ .password | required "customSecrets.admin.password is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/cp-pull-credentials-secret.yaml
+++ b/charts/awx-operator/templates/secrets/cp-pull-credentials-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "cpPullCredentials" }}
+{{- with $.Values.customSecrets.cpPullCredentials }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cpPullCredentials.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "dockerconfigjson.b64enc" .dockerconfig | required "customSecrets.cpPullCredentials.dockerconfig is required!" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/custom-certs-secret.yaml
+++ b/charts/awx-operator/templates/secrets/custom-certs-secret.yaml
@@ -1,0 +1,49 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- with .Values.customSecrets }}
+{{- $hasLdapCrt := (hasKey $.Values.customSecrets "ldapCacert") -}}
+{{- $hasBundleCrt := (hasKey . "bundleCacert") -}}
+{{- if or $hasLdapCrt $hasBundleCrt }}
+{{- $ldapCrtEnabled := ternary (.ldapCacert).enabled false $hasLdapCrt -}}
+{{- $bundleCrtEnabled := ternary (.bundleCacert).enabled false $hasBundleCrt -}}
+{{- $ldapSecretName := (include "ldapCacert.secretName" $) -}}
+{{- $bundleSecretName := (include "bundleCacert.secretName" $) -}}
+{{- if and (or $bundleCrtEnabled $ldapCrtEnabled) (eq $ldapSecretName $bundleSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ldapSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+{{- if $ldapCrtEnabled }}
+  ldap-ca.crt: {{ .ldapCacert.crt | required "customSecrets.ldapCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- if $bundleCrtEnabled }}
+  bundle-ca.crt: {{ .bundleCacert.crt | required "customSecrets.bundleCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- else }}
+{{- if $ldapCrtEnabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ldapSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  ldap-ca.crt: {{ .ldapCacert.crt | required "customSecrets.ldapCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- if $bundleCrtEnabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $bundleSecretName }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  bundle-ca.crt: {{ .bundleCacert.crt | required "customSecrets.bundleCacert.crt is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/ee-pull-credentials-secret.yaml
+++ b/charts/awx-operator/templates/secrets/ee-pull-credentials-secret.yaml
@@ -1,0 +1,19 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "eePullCredentials" }}
+{{- with $.Values.customSecrets.eePullCredentials }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "eePullCredentials.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+stringData:
+  url: {{ (required "customSecrets.eePullCredentials.url is required!" .url) | quote }}
+  username: {{ (required "customSecrets.eePullCredentials.username is required!" .username) | quote }}
+  password: {{ (required "customSecrets.eePullCredentials.password is required!" .password) | quote }}
+  ssl_verify: {{ or .sslVerify (eq (.sslVerify | toString) "<nil>") | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/ingress-tls-secret.yaml
+++ b/charts/awx-operator/templates/secrets/ingress-tls-secret.yaml
@@ -1,0 +1,25 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "ingressTls" }}
+{{- with $.Values.customSecrets.ingressTls }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ingressTls.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- if .labels }}
+  labels:
+{{ toYaml .labels | indent 4 }}
+{{- end }}
+type: kubernetes.io/tls
+data:
+{{- if .selfSignedCert }}
+{{ ( include "ingress.gen-certs" $ ) | indent 2 }}
+{{ else }}
+  tls.key: {{ (.key | required "customSecrets.ingressTls.key is required!") | b64enc }}
+  tls.crt: {{ (.certificate | required "customSecrets.ingressTls.certificate is required!") | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/ldap-password-secret.yaml
+++ b/charts/awx-operator/templates/secrets/ldap-password-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "ldap" }}
+{{- with $.Values.customSecrets.ldap }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ldap.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+data:
+  ldap-password: {{ .password | required "customSecrets.ldap.password is required!" | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/route-tls-secret.yaml
+++ b/charts/awx-operator/templates/secrets/route-tls-secret.yaml
@@ -1,0 +1,17 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "routeTls" }}
+{{- with $.Values.customSecrets.routeTls }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "routeTls.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.key: {{ (.key | required "customSecrets.routeTls.key is required!") | b64enc }}
+  tls.crt: {{ (.certificate | required "customSecrets.routeTls.certificate is required!") | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/secrets/secret-key-secret.yaml
+++ b/charts/awx-operator/templates/secrets/secret-key-secret.yaml
@@ -1,0 +1,16 @@
+{{- if ($.Values.customSecrets).enabled }}
+{{- if hasKey .Values.customSecrets "secretKey" }}
+{{- with $.Values.customSecrets.secretKey }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secretKey.secretName" $ }}
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+stringData:
+  secret_key: {{ .key | required "customSecrets.secretKey.key is required!" | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/service-awx-operator-controller-manager-metrics-service.yaml
+++ b/charts/awx-operator/templates/service-awx-operator-controller-manager-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    helm.sh/chart: awx-operator
+  name: awx-operator-controller-manager-metrics-service
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    control-plane: controller-manager
+    helm.sh/chart: awx-operator

--- a/charts/awx-operator/templates/serviceaccount-awx-operator-controller-manager.yaml
+++ b/charts/awx-operator/templates/serviceaccount-awx-operator-controller-manager.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: awx-operator
+  name: awx-operator-controller-manager

--- a/charts/awx-operator/templates/storage/_helpers.tpl
+++ b/charts/awx-operator/templates/storage/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Generate the name of the persistent volume for postgres folders
+*/}}
+{{- define "postgres.persistentVolumeName" -}}
+{{ printf "%s-postgres-volume" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the persistent volume for projects folder
+*/}}
+{{- define "projects.persistentVolumeName" -}}
+{{ printf "%s-projects-volume" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the persistent volume claim for the projects volume
+*/}}
+{{- define "projects.persistentVolumeClaim" -}}
+{{ printf "%s-projects-claim" $.Values.AWX.name }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class to use for the postgres volume
+*/}}
+{{- define "postgres.storageClassName" -}}
+{{ default (printf "%s-postgres-volume" $.Values.AWX.name) (default $.Values.AWX.spec.postgres_storage_class (($.Values.customVolumes).postgres).storageClassName) }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class to use for the projects volume
+*/}}
+{{- define "projects.storageClassName" -}}
+{{ default (printf "%s-projects-volume" $.Values.AWX.name) (default $.Values.AWX.spec.projects_storage_class (($.Values.customVolumes).projects).storageClassName) }}
+{{- end }}
+
+{{/*
+Generate the name of the storage class names, expects AWX context passed in
+*/}}
+{{- define "spec.storageClassNames" -}}
+{{- if and (not $.Values.AWX.postgres.enabled) (eq (($.Values.AWX.spec).postgres_configuration_secret | default "") "") -}}
+{{- if (($.Values.customVolumes).postgres).enabled -}}
+  {{- if not (hasKey $.Values.AWX.spec "postgres_storage_class") }}
+  postgres_storage_class: {{ include "postgres.storageClassName" $ }}    
+  {{- end }}
+  {{- if not (hasKey $.Values.AWX.spec "postgres_storage_requirements") }}
+  postgres_storage_requirements:
+    requests:
+      storage: {{ default "8Gi" $.Values.customVolumes.postgres.size | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- if and ($.Values.AWX.spec.projects_persistence) (eq (($.Values.AWX.spec).projects_existing_claim | default "") "") -}}
+{{- if (($.Values.customVolumes).projects).enabled }}
+  projects_existing_claim: {{ include "projects.persistentVolumeClaim" $ }} 
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/storage/postgres-pv.yaml
+++ b/charts/awx-operator/templates/storage/postgres-pv.yaml
@@ -1,0 +1,19 @@
+{{- if and (not $.Values.AWX.postgres.enabled) (eq (($.Values.AWX.spec).postgres_configuration_secret | default "") "") -}}
+{{- if (($.Values.customVolumes).postgres).enabled -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "postgres.persistentVolumeName" $ }}
+{{- with $.Values.customVolumes.postgres }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .accessModes }}
+  persistentVolumeReclaimPolicy: {{ default "Retain" .reclaimPolicy | quote }}
+  capacity:
+    storage: {{ default "8Gi" .size | quote }}
+  storageClassName: {{ include "postgres.storageClassName" $ }}
+  hostPath:
+    path: /var/lib/pgsql/data/userdata
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/templates/storage/projects-pv.yaml
+++ b/charts/awx-operator/templates/storage/projects-pv.yaml
@@ -1,0 +1,32 @@
+{{- if and ($.Values.AWX.spec.projects_persistence) (eq (($.Values.AWX.spec).projects_existing_claim | default "") "") -}}
+{{- if (($.Values.customVolumes).projects).enabled -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "projects.persistentVolumeName" $ }}
+{{- with $.Values.customVolumes.projects }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" (default $.Values.AWX.spec.projects_storage_access_mode .accessModes) }}
+  persistentVolumeReclaimPolicy: {{ default "Retain" .reclaimPolicy | quote }}
+  capacity:
+    storage: {{ default "8Gi" (default $.Values.AWX.spec.projects_storage_size .size) | quote }}
+  storageClassName: {{ include "projects.storageClassName" $ }}
+  hostPath:
+    path: {{ required "customVolumes.projects.hostPath is required!" .hostPath | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "projects.persistentVolumeClaim" $ }} 
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" (default $.Values.AWX.spec.projects_storage_access_mode .accessModes) }}
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ default "8Gi" (default $.Values.AWX.spec.projects_storage_size .size) | quote }}
+  storageClassName: {{ include "projects.storageClassName" $ }}
+{{- end }}  
+{{- end }}
+{{- end }}

--- a/charts/awx-operator/values.yaml
+++ b/charts/awx-operator/values.yaml
@@ -1,0 +1,21 @@
+AWX:
+  # enable use of awx-deploy template
+  enabled: false
+  name: awx
+  spec:
+    admin_user: admin
+
+  # configurations for external postgres instance
+  postgres:
+    enabled: false
+    host: Unset
+    port: 5678
+    dbName: Unset
+    username: admin
+    # for secret management, pass in the password independently of this file
+    # at the command line, use --set AWX.postgres.password
+    password: Unset
+    sslmode: prefer
+    type: unmanaged
+
+controller: {}


### PR DESCRIPTION
@oraNod hopefully this takes care of it

Validation: This has been merged to my fork and the changes worked successfully. Doesn't need to worry about branch protections since the releaser does nothing on master.

### Fork demo PRs:
1. ["good PR"](https://github.com/miles-w-3/awx-operator-helm/pull/12) - this is an example of a standard change. Version is incremented and generated chart is committed, so the validator is happy
2. ["ignored PR"](https://github.com/miles-w-3/awx-operator-helm/pull/11) - this one doesn't touch anything to do with the chart, just the readme. The chart-releaser release is skipped, and the validator is happy
3. ["bad PR"](https://github.com/miles-w-3/awx-operator-helm/pull/7) - this one increments the version, but does not rebuild the chart. Validator doesn't let this one through

### Conclusion
I already merged 1 and 2 to ensure they behave as expected, and then i reset my fork's main branch back to the content of this PR so that I could demo them


There is additional scope for improving the PR validator to make it fail if the chart is being changed and `version` already exists as another release. I can work on that sometime soon but it shouldn't block us getting releases going IMO.