### PR TITLE
update docs to align with templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,48 +186,48 @@ AWX:
     enabled: false
     ...
 
-  customSecrets:
+customSecrets:
+  enabled: true
+  admin:
     enabled: true
-    admin:
-      enabled: true
-      password: mysuperlongpassword
-      secretName: my-admin-password
-    secretKey:
-      enabled: true
-      key: supersecuresecretkey
-      secretName: my-awx-secret-key
-    ingressTls:
-      enabled: true
-      selfSignedCert: true
-      key: unset
-      certificate: unset
-    routeTls:
-      enabled: false
-      key: <contentoftheprivatekey>
-      certificate: <contentofthepublickey>
-    ldapCacert:
-      enabled: false
-      crt: <contentofmybundlecacrt>
-    ldap:
-      enabled: true
-      password: yourldapdnpassword
-    bundleCacert:
-      enabled: false
-      crt: <contentofmybundlecacrt>
-    eePullCredentials:
-      enabled: false
-      url: unset
-      username: unset
-      password: unset
-      sslVerify: true
-      secretName: my-ee-pull-credentials
-    cpPullCredentials:
-      enabled: false
-      dockerconfig:
-        - registry: https://index.docker.io/v1/
-          username: unset
-          password: unset
-      secretName: my-cp-pull-credentials
+    password: mysuperlongpassword
+    secretName: my-admin-password
+  secretKey:
+    enabled: true
+    key: supersecuresecretkey
+    secretName: my-awx-secret-key
+  ingressTls:
+    enabled: true
+    selfSignedCert: true
+    key: unset
+    certificate: unset
+  routeTls:
+    enabled: false
+    key: <contentoftheprivatekey>
+    certificate: <contentofthepublickey>
+  ldapCacert:
+    enabled: false
+    crt: <contentofmybundlecacrt>
+  ldap:
+    enabled: true
+    password: yourldapdnpassword
+  bundleCacert:
+    enabled: false
+    crt: <contentofmybundlecacrt>
+  eePullCredentials:
+    enabled: false
+    url: unset
+    username: unset
+    password: unset
+    sslVerify: true
+    secretName: my-ee-pull-credentials
+  cpPullCredentials:
+    enabled: false
+    dockerconfig:
+      - registry: https://index.docker.io/v1/
+        username: unset
+        password: unset
+    secretName: my-cp-pull-credentials
 ```
 
 ### Custom volumes


### PR DESCRIPTION
This change aligns the readme file with the code that's inside of the templates. The readme currently states that the `customSecrets` need to be nested under the AWX key.

[customSecrets](https://github.com/ansible-community/awx-operator-helm?tab=readme-ov-file#custom-secrets) section of the readme. 
```
AWX:
  # enable use of awx-deploy template
  ...

  # configurations for external postgres instance
  postgres:
    enabled: false
    ...

  customSecrets:
    enabled: true
    admin:
      enabled: true
      password: mysuperlongpassword
      secretName: my-admin-password
```
From the [admin-password-secret.yaml](https://github.com/ansible-community/awx-operator-helm/blob/main/.helm/starter/templates/secrets/admin-password-secret.yaml) this file, along with the other templates in the secrets folder, states the custom secrets section needs to unindented to be rendered by helm.
```
{{- if ($.Values.customSecrets).enabled }}
{{- if hasKey .Values.customSecrets "admin" }}
{{- with $.Values.customSecrets.admin }}
{{- if .enabled }}
apiVersion: v1
kind: Secret
metadata:
  name: {{ include "admin.secretName" $ }}
  namespace: {{ $.Release.Namespace }}
type: Opaque
data:
  password: {{ .password | required "customSecrets.admin.password is required!" | b64enc }}
{{- end }}
{{- end }}
{{- end }}
{{- end }}
```
